### PR TITLE
zsh-completions: correct instructions for fixing compaudit

### DIFF
--- a/Formula/z/zsh-completions.rb
+++ b/Formula/z/zsh-completions.rb
@@ -38,7 +38,7 @@ class ZshCompletions < Formula
       Additionally, if you receive "zsh compinit: insecure directories" warnings when attempting
       to load these completions, you may need to run this:
 
-        chmod go-w '/opt/homebrew/share'
+        chmod go-w '#{HOMEBREW_PREFIX}/share'
         chmod -R go-w '#{HOMEBREW_PREFIX}/share/zsh'
     EOS
   end

--- a/Formula/z/zsh-completions.rb
+++ b/Formula/z/zsh-completions.rb
@@ -38,6 +38,7 @@ class ZshCompletions < Formula
       Additionally, if you receive "zsh compinit: insecure directories" warnings when attempting
       to load these completions, you may need to run this:
 
+        chmod go-w '/opt/homebrew/share'
         chmod -R go-w '#{HOMEBREW_PREFIX}/share/zsh'
     EOS
   end


### PR DESCRIPTION
Issue #121742 details an issue with the instructions at the end of the zsh-completions formula. Specifically, there is an issue with directory permissions that the instructions suggest fixing, however those instructions are incomplete. The permissions must be fixed recursively for `/opt/homebrew/share/zsh` _as well as_ for `/opt/homebrew/share` (non-recursively).

I confirmed that the suggested fix in #121742 works for me locally on an M1 Mac. This PR updates the instructions to reflect that verified fix.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
